### PR TITLE
nucleo-l496zg: some fixes for LPUART

### DIFF
--- a/boards/nucleo-l496zg/Makefile.dep
+++ b/boards/nucleo-l496zg/Makefile.dep
@@ -1,1 +1,3 @@
+FEATURES_REQUIRED += periph_lpuart
+
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l496zg/Makefile.features
+++ b/boards/nucleo-l496zg/Makefile.features
@@ -4,7 +4,7 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart periph_lpuart
 
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo144/Makefile.features

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -90,7 +90,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
         /* Port G requires external power supply */
         periph_clk_en(APB1, RCC_APB1ENR1_PWREN);
         PWR->CR2 |= PWR_CR2_IOSV;
-        periph_clk_dis(APB1, RCC_APB1ENR1_PWREN);
     }
 #endif /* PWR_CR2_IOSV */
 #else


### PR DESCRIPTION
Hi,

I ran a test of your branch, which works with some small fixes ;)
- nucleo-l496zg needs to provide and use `periph_lpuart` feature
- I think it's safer to not disable `PWR` clock (I remember some issues with this, and we took a "drastic" measure to have it enabled, see https://github.com/RIOT-OS/RIOT/blob/e07ea98bc3ea91194049f6e4d86658267b9174f6/cpu/stm32_common/cpu_init.c#L49)

Feel free to squash this into your commits!