### PR TITLE
tests/nimble_l2cap: adjust buffer sizes for nrf51

### DIFF
--- a/boards/common/nrf51/Makefile.include
+++ b/boards/common/nrf51/Makefile.include
@@ -7,6 +7,11 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # include common nrf51 headers
 INCLUDES += -I$(RIOTBOARD)/common/nrf51/include
 
+# use alternative xtimer mapping if applicable
+ifneq (,$(filter nimble,$(USEPKG)))
+  CFLAGS += -DBOARD_NRF51_XTIMER_ALT
+endif
+
 ifeq ($(PROGRAMMER),openocd)
   # use common openocd configuration for nrf51
   export OPENOCD_CONFIG = $(RIOTBOARD)/common/nrf51/dist/openocd.cfg

--- a/boards/common/nrf51/include/board_common.h
+++ b/boards/common/nrf51/include/board_common.h
@@ -31,9 +31,22 @@ extern "C" {
 
 /**
  * @name    Xtimer configuration
+ *
+ * Some external packages (e.g. NimBLE) require dedicated access to timer 0.
+ * Setting the BOARD_NRF51_XTIMER_ALT variable allows to change the default
+ * xtimer configuration to use
+ *
  * @{
  */
+#ifndef BOARD_NRF51_XTIMER_ALT
+/* default xtimer mapping */
 #define XTIMER_WIDTH                (24)
+#else
+/* alternative mapping to TIMER_DEV(1) */
+#define XTIMER_DEV                  TIMER_DEV(1)
+#define XTIMER_WIDTH                (16)
+#define XTIMER_CHAN                 (0)
+#endif
 #define XTIMER_BACKOFF              (40)
 /** @} */
 

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -64,8 +64,8 @@ nimble_transport_ram:
 nimble_controller:
 	"$(MAKE)" -C $(PDIR)/nimble/controller/src/ -f $(TDIR)/controller.mk
 
-nimble_drivers:
-	"$(MAKE)" -C $(PDIR)/nimble/drivers/$(CPU_FAM)/src/ -f $(TDIR)/drivers.mk
+nimble_drivers_nrf5x:
+	"$(MAKE)" -C $(PDIR)/nimble/drivers/$(CPU_FAM)/src/ -f $(TDIR)/drivers.nrf5x.mk
 
 # additional, RIOT specific nimble modules
 nimble_addr:

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -64,8 +64,8 @@ nimble_transport_ram:
 nimble_controller:
 	"$(MAKE)" -C $(PDIR)/nimble/controller/src/ -f $(TDIR)/controller.mk
 
-nimble_drivers_nrf52:
-	"$(MAKE)" -C $(PDIR)/nimble/drivers/nrf52/src/ -f $(TDIR)/drivers.nrf52.mk
+nimble_drivers:
+	"$(MAKE)" -C $(PDIR)/nimble/drivers/$(CPU_FAM)/src/ -f $(TDIR)/drivers.mk
 
 # additional, RIOT specific nimble modules
 nimble_addr:

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -29,9 +29,7 @@ endif
 # nimble controller dependencies
 ifneq (,$(filter nimble_controller,$(USEMODULE)))
   USEMODULE += nimble_transport_ram
-  ifeq (nrf52,$(CPU_FAM))
-    USEMODULE += nimble_drivers_nrf52
-  endif
+  USEMODULE += nimble_drivers
 endif
 
 ifneq (,$(filter nimble_addr,$(USEMODULE)))

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -29,7 +29,9 @@ endif
 # nimble controller dependencies
 ifneq (,$(filter nimble_controller,$(USEMODULE)))
   USEMODULE += nimble_transport_ram
-  USEMODULE += nimble_drivers
+  ifneq (,$(filter nrf5%,$(CPU_FAM)))
+    USEMODULE += nimble_drivers_nrf5x
+  endif
 endif
 
 ifneq (,$(filter nimble_addr,$(USEMODULE)))

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -17,7 +17,7 @@ ifneq (,$(filter nimble_controller,$(USEMODULE)))
   CFLAGS += -DNIMBLE_CFG_CONTROLLER=1
   CFLAGS += -DMYNEWT_VAL_OS_CPUTIME_FREQ=32768
 
-  ifneq (,$(filter nimble_drivers,$(USEMODULE)))
+  ifneq (,$(filter nimble_drivers_nrf5x,$(USEMODULE)))
     INCLUDES += $(NIMIBASE)/nimble/drivers/$(CPU_FAM)/include
   endif
 endif

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -17,8 +17,8 @@ ifneq (,$(filter nimble_controller,$(USEMODULE)))
   CFLAGS += -DNIMBLE_CFG_CONTROLLER=1
   CFLAGS += -DMYNEWT_VAL_OS_CPUTIME_FREQ=32768
 
-  ifneq (,$(filter nimble_drivers_nrf52,$(USEMODULE)))
-    INCLUDES += $(NIMIBASE)/nimble/drivers/nrf52/include
+  ifneq (,$(filter nimble_drivers,$(USEMODULE)))
+    INCLUDES += $(NIMIBASE)/nimble/drivers/$(CPU_FAM)/include
   endif
 endif
 

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -36,7 +36,9 @@
 #endif
 
 #ifdef MODULE_NIMBLE_CONTROLLER
+#if defined(CPU_FAM_NRF52) || defined(CPU_FAM_NRF51)
 #include "nrf_clock.h"
+#endif
 
 static char _stack_controller[NIMBLE_CONTROLLER_STACKSIZE];
 #endif
@@ -54,7 +56,9 @@ static void *_host_thread(void *arg)
 
 #ifdef MODULE_NIMBLE_CONTROLLER
     /* XXX: NimBLE needs the nRF5x's LF clock to run */
+#if defined(CPU_FAM_NRF52) || defined(CPU_FAM_NRF51)
     clock_start_lf();
+#endif
 
     /* Run the controller
      *

--- a/pkg/nimble/contrib/nimble_riot.c
+++ b/pkg/nimble/contrib/nimble_riot.c
@@ -36,9 +36,7 @@
 #endif
 
 #ifdef MODULE_NIMBLE_CONTROLLER
-#ifdef CPU_FAM_NRF52
 #include "nrf_clock.h"
-#endif
 
 static char _stack_controller[NIMBLE_CONTROLLER_STACKSIZE];
 #endif
@@ -56,9 +54,8 @@ static void *_host_thread(void *arg)
 
 #ifdef MODULE_NIMBLE_CONTROLLER
     /* XXX: NimBLE needs the nRF5x's LF clock to run */
-#ifdef CPU_FAM_NRF52
     clock_start_lf();
-#endif
+
     /* Run the controller
      *
      * Create task where NimBLE LL will run. This one is required as LL has its

--- a/pkg/nimble/drivers.mk
+++ b/pkg/nimble/drivers.mk
@@ -1,3 +1,3 @@
-MODULE = nimble_drivers_nrf52
+MODULE = nimble_drivers
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/drivers.nrf5x.mk
+++ b/pkg/nimble/drivers.nrf5x.mk
@@ -1,3 +1,3 @@
-MODULE = nimble_drivers
+MODULE = nimble_drivers_nrf5x
 
 include $(RIOTBASE)/Makefile.base

--- a/tests/nimble_l2cap_server/nimble.inc.mk
+++ b/tests/nimble_l2cap_server/nimble.inc.mk
@@ -1,3 +1,14 @@
+# For nRF51-based targets, we need to reduce buffer sizes to make this test fit
+# into RAM
+# Note: as the CPU variable is not set at this point, we manually 'whitelist'
+#       all supported nrf51-boards here
+BOARDS_NRF51 := airfy-beacon calliope-mini microbit nrf51dk nrf51dongle \
+                nrf6310 yunjia-nrf51822
+ifneq (,$(filter $(BOARDS_NRF51),$(BOARD)))
+  APP_MTU ?= 250
+  MSYS_CNT ?= 6
+endif
+
 # Set the tests default configuration
 APP_MTU ?= 5000
 APP_BUF_CHUNKSIZE ?= 250    # must be full divider of APP_MTU
@@ -14,10 +25,11 @@ CFLAGS += -DAPP_CID=$(APP_CID)
 
 # configure NimBLE
 USEPKG += nimble
+MSYS_CNT ?= 23
 CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MAX_NUM=1
 CFLAGS += -DMYNEWT_VAL_BLE_L2CAP_COC_MPS=250
 CFLAGS += -DMYNEWT_VAL_BLE_MAX_CONNECTIONS=1
-CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=23
+CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_COUNT=$(MSYS_CNT)
 CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE=298
 CFLAGS += -DMYNEWT_VAL_BLE_LL_CFG_FEAT_DATA_LEN_EXT=1
 


### PR DESCRIPTION
Enabling the `ble_nimble` feature for nrf51 boards will most likely let `tests/nimble_l2cap` fail due to missing RAM on those boards. This PR adds a crude enhancement to the test application, to limit the used buffers for those boards. Its not pretty, but should do the job for now...